### PR TITLE
0.5.1.1

### DIFF
--- a/.idea/NoSQLMap-v0.5.iml
+++ b/.idea/NoSQLMap-v0.5.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="Unittests" />
+  </component>
+</module>

--- a/nosqlmap.py
+++ b/nosqlmap.py
@@ -233,18 +233,19 @@ def options():
 					#Treat this as a DNS name
 					optionSet[0] = True
 					notDNS = False
+				else:
+					#If len(octets) != 4 is executed the block of code below is also run, but it is not necessary
+					#If the format of the IP is good, check and make sure the octets are all within acceptable ranges.
+					for item in octets:
+						try:
+							if int(item) < 0 or int(item) > 255:
+								print "Bad octet in IP address."
+								goodDigits = False
 
-				#If the format of the IP is good, check and make sure the octets are all within acceptable ranges.
-				for item in octets:
-					try:
-						if int(item) < 0 or int(item) > 255:
-							print "Bad octet in IP address."
-							goodDigits = False
+						except:
+							#Must be a DNS name (for now)
 
-					except:
-						#Must be a DNS name (for now)
-
-						notDNS = False
+							notDNS = False
 
 				#If everything checks out set the IP and break the loop
 				if goodDigits == True or notDNS == False:
@@ -307,9 +308,13 @@ def options():
 		elif select == "7":
 			#Unset the setting boolean since we're setting it again.
 			optionSet[4] = False
-			goodLen = False
-			goodDigits = False
+
 			while optionSet[4] == False:
+				goodLen = False
+				goodDigits = True
+				#Every time when user input Invalid IP, goodLen and goodDigits should be reset. If not do this, there will be a bug
+				#For example enter 10.0.0.1234 firtly and the goodLen will be set to True and goodDigits will be set to False
+				#Second step enter 10.0.123, because goodLen has already been set to True, this invalid IP will be put in myIP variables
 				myIP = raw_input("Enter the host IP for my " + platform +"/Shells: ")
 				#make sure we got a valid IP
 				octets = myIP.split(".")
@@ -327,8 +332,10 @@ def options():
 							print "Bad octet in IP address."
 							goodDigits = False
 
-						else:
-							goodDigits = True
+#						else:
+#							goodDigits = True
+						#Default value of goodDigits should be set to True
+						#for example 12.12345.12.12
 
 
 				#If everything checks out set the IP and break the loop

--- a/nsmcouch.py
+++ b/nsmcouch.py
@@ -14,7 +14,7 @@
 #along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-#test
+#test11
 import couchdb
 import urllib
 import requests

--- a/nsmcouch.py
+++ b/nsmcouch.py
@@ -14,7 +14,7 @@
 #along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-#test11
+#sunxiuyang
 import couchdb
 import urllib
 import requests

--- a/nsmcouch.py
+++ b/nsmcouch.py
@@ -14,7 +14,7 @@
 #along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-#sunxiuyang
+
 import couchdb
 import urllib
 import requests

--- a/nsmcouch.py
+++ b/nsmcouch.py
@@ -14,7 +14,7 @@
 #along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-
+#test
 import couchdb
 import urllib
 import requests
@@ -83,7 +83,6 @@ def netAttacks(target,port, myIP):
     mgtSelect = True
     #This is a global for future use with other modules; may change
     dbList = []
-
     print "Checking to see if credentials are needed..."
     needCreds = couchScan(target,port,False)
 


### PR DESCRIPTION
Fix two bugs of set my local MongoDB/Shell IP and there is little optimization in line number 237
**bug1:**
**line number** is 313
**Description:** Every time when user input Invalid IP, goodLen and goodDigits should be reset. If not do this, there will be a bug. For example enter 10.0.0.1234 firstly and the goodLen will be set to True and goodDigits will be set to False. Second step enter 10.0.123, because goodLen has already been set to True, this invalid IP will be put in myIP variables
set my local MongoDB/Shell IP
**leak test:**
first step:10.0.0.1234
second step:10.0.123


 **bug2:**
 **line number** is 335
**Description:**Default value of goodDigits should be set to True. And the logic of this if else in line number 335 is incorrect because is second octet is beyond the 255, this invalid IP will be put in myIP variables
 set my local MongoDB/Shell IP:
 **leak test:**
 12.123435.12.10